### PR TITLE
fix: maintain row numbers in Streamlit tables

### DIFF
--- a/app.py
+++ b/app.py
@@ -1132,7 +1132,20 @@ document.addEventListener('DOMContentLoaded', function() {
         childList: true,
         subtree: true
     });
-    
+
+    function updateRowNumbers() {
+        const tables = document.querySelectorAll('div[data-testid="stDataFrame"] table, div[data-testid="stTable"] table');
+        tables.forEach(table => {
+            const rows = table.querySelectorAll('tbody tr');
+            rows.forEach((row, idx) => {
+                const firstCell = row.querySelector('th, td');
+                if (firstCell) {
+                    firstCell.textContent = idx;
+                }
+            });
+        });
+    }
+
     function applyStyling() {
         const isDarkMode = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
         
@@ -1453,6 +1466,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 }
             });
         }
+        updateRowNumbers();
     }
     
     applyStyling();


### PR DESCRIPTION
## Summary
- ensure first-column row numbers remain sequential across all tables
- update JavaScript styling routine to reindex rows after sorting

## Testing
- `pytest -q` *(fails: SyntaxError in tests/test_auth.py, tests/test_db.py)*

------
https://chatgpt.com/codex/tasks/task_e_689582fcca148323b881c446bbea35bb