### PR TITLE
Use salted password hashes and migrate legacy entries

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -1,4 +1,4 @@
-import sqlite3, hashlib
+import sqlite3, hashlib, os, hmac
 
 def get_db():
     conn = sqlite3.connect("users.db")
@@ -12,8 +12,26 @@ def get_db():
     conn.commit()
     return conn
 
-def hash_password(pw):
-    return hashlib.sha256(pw.encode()).hexdigest()
+def hash_password(pw, salt=None, iterations=100_000):
+    """Create a salted PBKDF2 hash for the given password."""
+    if salt is None:
+        salt = os.urandom(16)
+    elif isinstance(salt, str):
+        salt = bytes.fromhex(salt)
+    pwd_hash = hashlib.pbkdf2_hmac('sha256', pw.encode(), salt, iterations)
+    return f"{salt.hex()}${pwd_hash.hex()}"
+
+def verify_password(pw, stored_hash, iterations=100_000):
+    """Verify a password against a stored hash. Supports legacy unsalted hashes."""
+    if '$' in stored_hash:
+        salt_hex, hash_hex = stored_hash.split('$', 1)
+        salt = bytes.fromhex(salt_hex)
+        calc_hash = hashlib.pbkdf2_hmac('sha256', pw.encode(), salt, iterations).hex()
+        return hmac.compare_digest(calc_hash, hash_hex)
+    else:
+        # Legacy SHA256 hash without salt
+        legacy = hashlib.sha256(pw.encode()).hexdigest()
+        return hmac.compare_digest(legacy, stored_hash)
 
 def ensure_permanent_credentials():
     """Ensure the permanent smartsolar user exists with correct password"""
@@ -24,17 +42,29 @@ def ensure_permanent_credentials():
     c.execute("SELECT password_hash FROM users WHERE username=?", ('smartsolar',))
     row = c.fetchone()
     
+    correct_pw = 'solar27'
     if row:
-        # Update password if it's different
-        correct_hash = hash_password('solar27')
-        if row[0] != correct_hash:
-            c.execute("UPDATE users SET password_hash=? WHERE username=?", 
-                     (correct_hash, 'smartsolar'))
+        stored_hash = row[0]
+        if verify_password(correct_pw, stored_hash):
+            if '$' not in stored_hash:
+                # Upgrade legacy hash to salted hash
+                c.execute(
+                    "UPDATE users SET password_hash=? WHERE username=?",
+                    (hash_password(correct_pw), 'smartsolar'),
+                )
+                conn.commit()
+        else:
+            c.execute(
+                "UPDATE users SET password_hash=? WHERE username=?",
+                (hash_password(correct_pw), 'smartsolar'),
+            )
             conn.commit()
     else:
         # Create the user if it doesn't exist
-        c.execute("INSERT INTO users (username, password_hash) VALUES (?, ?)",
-                  ('smartsolar', hash_password('solar27')))
+        c.execute(
+            "INSERT INTO users (username, password_hash) VALUES (?, ?)",
+            ('smartsolar', hash_password(correct_pw)),
+        )
         conn.commit()
     
     conn.close()
@@ -45,8 +75,23 @@ def check_login(user, pw):
     
     conn = get_db(); c = conn.cursor()
     c.execute("SELECT password_hash FROM users WHERE username=?", (user,))
-    row = c.fetchone(); conn.close()
-    return bool(row and row[0] == hash_password(pw))
+    row = c.fetchone()
+    if not row:
+        conn.close()
+        return False
+    stored_hash = row[0]
+    if verify_password(pw, stored_hash):
+        if '$' not in stored_hash:
+            # Upgrade legacy hash to salted hash
+            c.execute(
+                "UPDATE users SET password_hash=? WHERE username=?",
+                (hash_password(pw), user),
+            )
+            conn.commit()
+        conn.close()
+        return True
+    conn.close()
+    return False
 
 def create_user(user, pw):
     # Ensure permanent credentials are available
@@ -54,8 +99,10 @@ def create_user(user, pw):
     
     conn = get_db(); c = conn.cursor()
     try:
-        c.execute("INSERT INTO users (username, password_hash) VALUES (?, ?)",
-                  (user, hash_password(pw)))
+        c.execute(
+            "INSERT INTO users (username, password_hash) VALUES (?, ?)",
+            (user, hash_password(pw)),
+        )
         conn.commit()
         return True
     except sqlite3.IntegrityError:


### PR DESCRIPTION
## Summary
- switch to salted PBKDF2 password hashes and add verification helper
- ensure permanent account and new users store salted hashes, upgrading legacy hashes on use
- verify logins against salted or legacy hashes and automatically migrate old entries

## Testing
- `python -m py_compile auth.py app.py db.py`
- `python - <<'PY'
import auth, sqlite3, hashlib
from auth import get_db, hash_password, verify_password, check_login, create_user, ensure_permanent_credentials

conn = sqlite3.connect('users.db'); c = conn.cursor()
c.execute("SELECT username, password_hash FROM users")
print('Initial users:', c.fetchall())

legacy_hash = hashlib.sha256('pass'.encode()).hexdigest()
c.execute("INSERT INTO users (username, password_hash) VALUES (?,?)", ('legacy', legacy_hash))
conn.commit()
print('Inserted legacy user with hash length', len(legacy_hash))

print('Login legacy (correct):', check_login('legacy', 'pass'))
c.execute("SELECT password_hash FROM users WHERE username='legacy'")
print('Upgraded hash contains $:', '$' in c.fetchone()[0])
conn.close()
PY`


------
https://chatgpt.com/codex/tasks/task_e_6895440fa86883238af9a596d5d4e914