### PR TITLE
Clean up test files by removing diff artifacts

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,41 +1,39 @@
-+import sqlite3
-+import sys
-+from pathlib import Path
-+
-+sys.path.append(str(Path(__file__).resolve().parents[1]))
-+import auth
-+
-+
-+def make_test_db(tmp_path):
-+    db_path = tmp_path / "users.db"
-+    def _get_db():
-+        conn = sqlite3.connect(db_path)
-+        c = conn.cursor()
-+        c.execute(
-+            """
-+            CREATE TABLE IF NOT EXISTS users (
-+                username TEXT PRIMARY KEY,
-+                password_hash TEXT
-+            )
-+            """
-+        )
-+        conn.commit()
-+        return conn
-+    return _get_db
-+
-+
-+def test_update_password_returns_false_for_unknown_user(tmp_path, monkeypatch):
-+    monkeypatch.setattr(auth, "get_db", make_test_db(tmp_path))
-+    auth.ensure_permanent_credentials()
-+    assert auth.update_password("ghost", "pw") is False
-+
-+
-+def test_update_password_updates_existing_user(tmp_path, monkeypatch):
-+    monkeypatch.setattr(auth, "get_db", make_test_db(tmp_path))
-+    auth.ensure_permanent_credentials()
-+    assert auth.create_user("alice", "pw1")
-+    assert auth.update_password("alice", "pw2")
-+    assert auth.check_login("alice", "pw2")
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import auth
+
+
+def make_test_db(tmp_path):
+    db_path = tmp_path / "users.db"
+    def _get_db():
+        conn = sqlite3.connect(db_path)
+        c = conn.cursor()
+        c.execute(
+            """
+            CREATE TABLE IF NOT EXISTS users (
+                username TEXT PRIMARY KEY,
+                password_hash TEXT
+            )
+            """
+        )
+        conn.commit()
+        return conn
+    return _get_db
+
+
+def test_update_password_returns_false_for_unknown_user(tmp_path, monkeypatch):
+    monkeypatch.setattr(auth, "get_db", make_test_db(tmp_path))
+    auth.ensure_permanent_credentials()
+    assert auth.update_password("ghost", "pw") is False
+
+
+def test_update_password_updates_existing_user(tmp_path, monkeypatch):
+    monkeypatch.setattr(auth, "get_db", make_test_db(tmp_path))
+    auth.ensure_permanent_credentials()
+    assert auth.create_user("alice", "pw1")
+    assert auth.update_password("alice", "pw2")
+    assert auth.check_login("alice", "pw2")
  
-EOF
-)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,27 +1,25 @@
-+import sqlite3
-+import sys
-+import os
-+
-+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-+import db
-+
-+
-+def setup_module(module):
-+    db._conn = sqlite3.connect(":memory:", check_same_thread=False)
-+    db._cur = db._conn.cursor()
-+    db.init_db()
-+    db.delete_pcs("マルチパワコン")
-+
-+
-+def test_default_pcs_setting():
-+    db.save_pcs("PCS1", "Model1", 400.0, 100.0, 2, 10.0)
-+    db.save_pcs("PCS2", "Model2", 500.0, 120.0, 3, 12.0, is_default=True)
-+
-+    pcs = db.load_pcs()
-+
-+    assert pcs["PCS1"]["is_default"] is False
-+    assert pcs["PCS2"]["is_default"] is True
-+    assert sum(1 for p in pcs.values() if p["is_default"]) == 1
+import sqlite3
+import sys
+import os
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import db
+
+
+def setup_module(module):
+    db._conn = sqlite3.connect(":memory:", check_same_thread=False)
+    db._cur = db._conn.cursor()
+    db.init_db()
+    db.delete_pcs("マルチパワコン")
+
+
+def test_default_pcs_setting():
+    db.save_pcs("PCS1", "Model1", 400.0, 100.0, 2, 10.0)
+    db.save_pcs("PCS2", "Model2", 500.0, 120.0, 3, 12.0, is_default=True)
+
+    pcs = db.load_pcs()
+
+    assert pcs["PCS1"]["is_default"] is False
+    assert pcs["PCS2"]["is_default"] is True
+    assert sum(1 for p in pcs.values() if p["is_default"]) == 1
  
-EOF
-)


### PR DESCRIPTION
## Summary
- fix test files corrupted by diff markers
- ensure `make_test_db` and password update tests are valid
- clean up database test for default PCS handling

## Testing
- `pytest` *(fails: AssertionError: assert None is False)*

------
https://chatgpt.com/codex/tasks/task_e_6895a01b8d70832396f20139c905c94b