### PR TITLE
chore: update Japanese instruction text

### DIFF
--- a/app.py
+++ b/app.py
@@ -581,10 +581,10 @@ div[data-testid="stExpander"]:not([data-testid*="expanded"]) {
 """, unsafe_allow_html=True)
 
 # ─── 操作方法 ───
-st.markdown("\U0001F449 タブ\u2780\u2192\u2781\u2192\u2782を順番に確認し、回路構成可否を判定してください。")
+st.markdown("\U0001F449 タブ\u2460\u2192\u2461\u2192\u2462の順に確認し、回路構成が可能かどうかを判定してください")
 
 # ─── Cautions TAB ───
-with st.expander("**⚠️ 注意** ※タブを展開/最小化するにはここをタップ", expanded=False):
+with st.expander("**⚠️ 注意** ※タブの展開・折りたたみはここをタップしてください", expanded=False):
     st.markdown("""
         注1：本判定結果は回路構成の可否を判断するもので、設置可否を判断するものではありません。  
         注2：回路可能判定結果はモジュール・インバータリストに登録された電気特性を基に判定しています。  


### PR DESCRIPTION
## Summary
- update guidance to use circled numerals ①→②→③ and clarify circuit configuration judgement wording
- clarify caution text about expanding and collapsing tabs

## Testing
- `pytest -q` *(fails: AssertionError: assert None is False)*

------
https://chatgpt.com/codex/tasks/task_e_6895bf717c84832396ab9d8224437685