### PR TITLE
Prevent inverter tab auto-expansion

### DIFF
--- a/app.py
+++ b/app.py
@@ -592,7 +592,7 @@ with st.expander("**⚠️ 注意** ※タブを展開/最小化するにはこ�
     """)
 
 # ─── PCS SETTINGS TAB ───
-with st.expander("**【➀インバータ入力】**", expanded=st.session_state.get("menu_page", "PCS Settings") == "PCS Settings"):
+with st.expander("**【➀インバータ入力】**", expanded=st.session_state.get("menu_page") == "PCS Settings"):
     # PCS Settings content
     st.markdown(
         "<h4 style='margin-bottom: 10px;'>⚙️ インバータの追加・管理</h4>",
@@ -1080,7 +1080,7 @@ if st.session_state.get("show_logout_confirm", False):
 
 # Set default page if not set
 if "menu_page" not in st.session_state:
-    st.session_state.menu_page = "PCS Settings"
+    st.session_state.menu_page = None
 
 # JavaScript for enhanced styling
 st.markdown("""

--- a/auth.py
+++ b/auth.py
@@ -113,11 +113,20 @@ def create_user(user, pw):
 def update_password(user, new_pw):
     # Ensure permanent credentials are available
     ensure_permanent_credentials()
-    
+
     conn = get_db(); c = conn.cursor()
-    c.execute("UPDATE users SET password_hash=? WHERE username=?",
-              (hash_password(new_pw), user))
-    conn.commit(); conn.close()
+    c.execute("SELECT 1 FROM users WHERE username=?", (user,))
+    if not c.fetchone():
+        conn.close()
+        return False
+
+    c.execute(
+        "UPDATE users SET password_hash=? WHERE username=?",
+        (hash_password(new_pw), user),
+    )
+    conn.commit()
+    conn.close()
+    return True
 
 # Initialize permanent credentials when module is imported
 ensure_permanent_credentials()


### PR DESCRIPTION
## Summary
- Ensure inverter input expander stays collapsed on login by removing default session state page and leaving expanders closed
- Return explicit success status from `update_password` when updating existing users or when user not found

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895c2fc588083239efeda8be61ab18d